### PR TITLE
Buildfix

### DIFF
--- a/src/TimeTrackerWindow.cpp
+++ b/src/TimeTrackerWindow.cpp
@@ -228,7 +228,7 @@ TimeTrackerWindow::LoadTasks()
 				char Buffer[255];
 				sprintf(Buffer, "Task%d", pos);
 				const char*	TaskName;
-				TaskName = Tasks.FindString(Buffer, 0);
+				TaskName = Tasks.FindString(Buffer);
 				if (TaskName != NULL) {
 					sprintf(Buffer, "TaskTime%d", pos);
 					bigtime_t* time;


### PR DESCRIPTION
Fixes:

call of overloaded `FindString(char[255], int)' is ambiguous
  candidates are:
  status_t BMessage::FindString(const char *, const char **) const
  status_t BMessage::FindString(const char *, BString *) const
  const char * BMessage::FindString(const char *, long int = 0) const